### PR TITLE
feat: return uncompressed batch bytes length

### DIFF
--- a/encoding/codecv2/codecv2.go
+++ b/encoding/codecv2/codecv2.go
@@ -420,30 +420,30 @@ func (b *DABatch) Blob() *kzg4844.Blob {
 	return b.blob
 }
 
-// EstimateChunkL1CommitBlobSize estimates the size of the L1 commit blob for a single chunk.
-func EstimateChunkL1CommitBlobSize(c *encoding.Chunk) (uint64, error) {
+// EstimateChunkL1CommitBatchSizeAndBlobSize estimates the L1 commit uncompressed batch size and compressed blob size for a single chunk.
+func EstimateChunkL1CommitBatchSizeAndBlobSize(c *encoding.Chunk) (uint64, uint64, error) {
 	batchBytes, err := constructBatchPayload([]*encoding.Chunk{c})
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	blobBytes, err := compressScrollBatchBytes(batchBytes)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return codecv1.CalculatePaddedBlobSize(uint64(len(blobBytes))), nil
+	return uint64(len(batchBytes)), codecv1.CalculatePaddedBlobSize(uint64(len(blobBytes))), nil
 }
 
-// EstimateBatchL1CommitBlobSize estimates the total size of the L1 commit blob for a batch.
-func EstimateBatchL1CommitBlobSize(b *encoding.Batch) (uint64, error) {
+// EstimateBatchL1CommitBatchSizeAndBlobSize estimates the L1 commit uncompressed batch size and compressed blob size for a batch.
+func EstimateBatchL1CommitBatchSizeAndBlobSize(b *encoding.Batch) (uint64, uint64, error) {
 	batchBytes, err := constructBatchPayload(b.Chunks)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	blobBytes, err := compressScrollBatchBytes(batchBytes)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return codecv1.CalculatePaddedBlobSize(uint64(len(blobBytes))), nil
+	return uint64(len(batchBytes)), codecv1.CalculatePaddedBlobSize(uint64(len(blobBytes))), nil
 }
 
 // EstimateChunkL1CommitCalldataSize calculates the calldata size needed for committing a chunk to L1 approximately.

--- a/encoding/codecv2/codecv2_test.go
+++ b/encoding/codecv2/codecv2_test.go
@@ -796,45 +796,54 @@ func TestCodecV2BatchSkipBitmap(t *testing.T) {
 func TestCodecV2ChunkAndBatchBlobSizeEstimation(t *testing.T) {
 	trace2 := readBlockFromJSON(t, "../testdata/blockTrace_02.json")
 	chunk2 := &encoding.Chunk{Blocks: []*encoding.Block{trace2}}
-	chunk2BlobSize, err := EstimateChunkL1CommitBlobSize(chunk2)
+	chunk2BatchBytesSize, chunk2BlobSize, err := EstimateChunkL1CommitBatchSizeAndBlobSize(chunk2)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(412), chunk2BatchBytesSize)
 	assert.Equal(t, uint64(237), chunk2BlobSize)
 	batch2 := &encoding.Batch{Chunks: []*encoding.Chunk{chunk2}}
-	batch2BlobSize, err := EstimateBatchL1CommitBlobSize(batch2)
+	batch2BatchBytesSize, batch2BlobSize, err := EstimateBatchL1CommitBatchSizeAndBlobSize(batch2)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(412), batch2BatchBytesSize)
 	assert.Equal(t, uint64(237), batch2BlobSize)
 
 	trace3 := readBlockFromJSON(t, "../testdata/blockTrace_03.json")
 	chunk3 := &encoding.Chunk{Blocks: []*encoding.Block{trace3}}
-	chunk3BlobSize, err := EstimateChunkL1CommitBlobSize(chunk3)
+	chunk3BatchBytesSize, chunk3BlobSize, err := EstimateChunkL1CommitBatchSizeAndBlobSize(chunk3)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(5863), chunk3BatchBytesSize)
 	assert.Equal(t, uint64(2933), chunk3BlobSize)
 	batch3 := &encoding.Batch{Chunks: []*encoding.Chunk{chunk3}}
-	batch3BlobSize, err := EstimateBatchL1CommitBlobSize(batch3)
+	batch3BatchBytesSize, batch3BlobSize, err := EstimateBatchL1CommitBatchSizeAndBlobSize(batch3)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(5863), batch3BatchBytesSize)
 	assert.Equal(t, uint64(2933), batch3BlobSize)
 
 	trace4 := readBlockFromJSON(t, "../testdata/blockTrace_04.json")
 	chunk4 := &encoding.Chunk{Blocks: []*encoding.Block{trace4}}
-	chunk4BlobSize, err := EstimateChunkL1CommitBlobSize(chunk4)
+	chunk4BatchBytesSize, chunk4BlobSize, err := EstimateChunkL1CommitBatchSizeAndBlobSize(chunk4)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(214), chunk4BatchBytesSize)
 	assert.Equal(t, uint64(54), chunk4BlobSize)
 	batch4 := &encoding.Batch{Chunks: []*encoding.Chunk{chunk4}}
-	batch4BlobSize, err := EstimateBatchL1CommitBlobSize(batch4)
+	blob4BatchBytesSize, batch4BlobSize, err := EstimateBatchL1CommitBatchSizeAndBlobSize(batch4)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(214), blob4BatchBytesSize)
 	assert.Equal(t, uint64(54), batch4BlobSize)
 
 	chunk5 := &encoding.Chunk{Blocks: []*encoding.Block{trace2, trace3}}
-	chunk5BlobSize, err := EstimateChunkL1CommitBlobSize(chunk5)
+	chunk5BatchBytesSize, chunk5BlobSize, err := EstimateChunkL1CommitBatchSizeAndBlobSize(chunk5)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(6093), chunk5BatchBytesSize)
 	assert.Equal(t, uint64(3149), chunk5BlobSize)
 	chunk6 := &encoding.Chunk{Blocks: []*encoding.Block{trace4}}
-	chunk6BlobSize, err := EstimateChunkL1CommitBlobSize(chunk6)
+	chunk6BatchBytesSize, chunk6BlobSize, err := EstimateChunkL1CommitBatchSizeAndBlobSize(chunk6)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(214), chunk6BatchBytesSize)
 	assert.Equal(t, uint64(54), chunk6BlobSize)
 	batch5 := &encoding.Batch{Chunks: []*encoding.Chunk{chunk5, chunk6}}
-	batch5BlobSize, err := EstimateBatchL1CommitBlobSize(batch5)
+	batch5BatchBytesSize, batch5BlobSize, err := EstimateBatchL1CommitBatchSizeAndBlobSize(batch5)
 	assert.NoError(t, err)
+	assert.Equal(t, uint64(6125), batch5BatchBytesSize)
 	assert.Equal(t, uint64(3186), batch5BlobSize)
 }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Limit the decompressed bytes (original bytes) not larger than 1,000,000 since each decompressed byte would take 1 row in the zstd circuit and currently we have applied `k = 20`, the maximum allowed is 1,048,576, but since the circuit cannot fully use these rows, thus using 1,000,000 as the limit.

reusing `EstimateChunkL1CommitBlobSize` and `EstimateBatchL1CommitBlobSize` to avoid duplicated calculation.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] feat: A new feature

### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
