### PR TITLE
test(codecv3): add a JSON unit test

### DIFF
--- a/encoding/codecv3/codecv3_test.go
+++ b/encoding/codecv3/codecv3_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/da-codec/encoding/codecv0"
@@ -866,6 +867,57 @@ func TestCodecV3ChunkAndBatchCalldataSizeEstimation(t *testing.T) {
 	batch5 := &encoding.Batch{Chunks: []*encoding.Chunk{chunk5, chunk6}}
 	batch5CalldataSize := EstimateBatchL1CommitCalldataSize(batch5)
 	assert.Equal(t, uint64(180), batch5CalldataSize)
+}
+
+func TestCodecV3DABatchJSON(t *testing.T) {
+	trace2 := readBlockFromJSON(t, "../testdata/blockTrace_02.json")
+	chunk2 := &encoding.Chunk{Blocks: []*encoding.Block{trace2}}
+	originalBatch := &encoding.Batch{Chunks: []*encoding.Chunk{chunk2}}
+	original, err := NewDABatch(originalBatch)
+	assert.NoError(t, err)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded DABatch
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Version, decoded.Version)
+	assert.Equal(t, original.BatchIndex, decoded.BatchIndex)
+	assert.Equal(t, original.L1MessagePopped, decoded.L1MessagePopped)
+	assert.Equal(t, original.TotalL1MessagePopped, decoded.TotalL1MessagePopped)
+	assert.Equal(t, original.DataHash, decoded.DataHash)
+	assert.Equal(t, original.BlobVersionedHash, decoded.BlobVersionedHash)
+	assert.Equal(t, original.ParentBatchHash, decoded.ParentBatchHash)
+	assert.Equal(t, original.LastBlockTimestamp, decoded.LastBlockTimestamp)
+	assert.Equal(t, original.BlobDataProof, decoded.BlobDataProof)
+
+	jsonStr := `{
+		"Version": 3,
+		"BatchIndex": 0,
+		"L1MessagePopped": 0,
+		"TotalL1MessagePopped": 0,
+		"DataHash": "0x9f81f6879f121da5b7a37535cdb21b3d53099266de57b1fdf603ce32100ed541",
+		"BlobVersionedHash": "0x01bbc6b98d7d3783730b6208afac839ad37dcf211b9d9e7c83a5f9d02125ddd7",
+		"ParentBatchHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"LastBlockTimestamp": 1669364522,
+		"BlobDataProof": [9, 143, 31, 19, 111, 87, 52, 3, 152, 24, 190, 227, 82, 34, 211, 90, 150, 172, 215, 209, 113, 32, 206, 136, 22, 48, 117, 39, 209, 155, 173, 234, 23, 208, 19, 190, 94, 246, 150, 207, 188, 5, 185, 123, 179, 34, 165, 135, 67, 44, 44, 178, 60, 72, 72, 212, 215, 203, 132, 83, 196, 117, 179, 141]
+	}`
+
+	var expected DABatch
+	err = json.Unmarshal([]byte(jsonStr), &expected)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected.Version, decoded.Version)
+	assert.Equal(t, expected.BatchIndex, decoded.BatchIndex)
+	assert.Equal(t, expected.L1MessagePopped, decoded.L1MessagePopped)
+	assert.Equal(t, expected.TotalL1MessagePopped, decoded.TotalL1MessagePopped)
+	assert.Equal(t, expected.DataHash, decoded.DataHash)
+	assert.Equal(t, expected.BlobVersionedHash, decoded.BlobVersionedHash)
+	assert.Equal(t, expected.ParentBatchHash, decoded.ParentBatchHash)
+	assert.Equal(t, expected.LastBlockTimestamp, decoded.LastBlockTimestamp)
+	assert.Equal(t, expected.BlobDataProof, decoded.BlobDataProof)
 }
 
 func readBlockFromJSON(t *testing.T, filename string) *encoding.Block {


### PR DESCRIPTION
### Purpose or design rationale of this PR

https://github.com/scroll-tech/scroll/blob/088f92f81674cc7577b614b17171243d51319105/common/types/message/message.go#L159

batch header JSON string will be used as an input field of bundle prover, this PR adds a related JSON unit test for clarity.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] test: Adding missing tests or correcting existing tests

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
