### PR TITLE
refactor: align batchBytes and blobBytes with zkEVM namings

### DIFF
--- a/encoding/codecv2/codecv2.go
+++ b/encoding/codecv2/codecv2.go
@@ -123,8 +123,8 @@ func ConstructBlobPayload(chunks []*encoding.Chunk, useMockTxData bool) (*kzg484
 	// metadata consists of num_chunks (2 bytes) and chunki_size (4 bytes per chunk)
 	metadataLength := 2 + MaxNumChunks*4
 
-	// the raw (un-compressed and un-padded) blob payload
-	blobBytes := make([]byte, metadataLength)
+	// batchBytes represents the raw (un-compressed and un-padded) blob payload
+	batchBytes := make([]byte, metadataLength)
 
 	// challenge digest preimage
 	// 1 hash for metadata, 1 hash for each chunk, 1 hash for blob versioned hash
@@ -134,12 +134,12 @@ func ConstructBlobPayload(chunks []*encoding.Chunk, useMockTxData bool) (*kzg484
 	var chunkDataHash common.Hash
 
 	// blob metadata: num_chunks
-	binary.BigEndian.PutUint16(blobBytes[0:], uint16(len(chunks)))
+	binary.BigEndian.PutUint16(batchBytes[0:], uint16(len(chunks)))
 
 	// encode blob metadata and L2 transactions,
 	// and simultaneously also build challenge preimage
 	for chunkID, chunk := range chunks {
-		currentChunkStartIndex := len(blobBytes)
+		currentChunkStartIndex := len(batchBytes)
 
 		for _, block := range chunk.Blocks {
 			for _, tx := range block.Transactions {
@@ -152,17 +152,17 @@ func ConstructBlobPayload(chunks []*encoding.Chunk, useMockTxData bool) (*kzg484
 				if err != nil {
 					return nil, common.Hash{}, nil, err
 				}
-				blobBytes = append(blobBytes, rlpTxData...)
+				batchBytes = append(batchBytes, rlpTxData...)
 			}
 		}
 
 		// blob metadata: chunki_size
-		if chunkSize := len(blobBytes) - currentChunkStartIndex; chunkSize != 0 {
-			binary.BigEndian.PutUint32(blobBytes[2+4*chunkID:], uint32(chunkSize))
+		if chunkSize := len(batchBytes) - currentChunkStartIndex; chunkSize != 0 {
+			binary.BigEndian.PutUint32(batchBytes[2+4*chunkID:], uint32(chunkSize))
 		}
 
 		// challenge: compute chunk data hash
-		chunkDataHash = crypto.Keccak256Hash(blobBytes[currentChunkStartIndex:])
+		chunkDataHash = crypto.Keccak256Hash(batchBytes[currentChunkStartIndex:])
 		copy(challengePreimage[32+chunkID*32:], chunkDataHash[:])
 	}
 
@@ -175,26 +175,26 @@ func ConstructBlobPayload(chunks []*encoding.Chunk, useMockTxData bool) (*kzg484
 	}
 
 	// challenge: compute metadata hash
-	hash := crypto.Keccak256Hash(blobBytes[0:metadataLength])
+	hash := crypto.Keccak256Hash(batchBytes[0:metadataLength])
 	copy(challengePreimage[0:], hash[:])
 
-	// compress blob bytes
-	compressedBlobBytes, err := compressScrollBatchBytes(blobBytes)
+	// blobBytes represents the compressed blob payload (batchBytes)
+	blobBytes, err := compressScrollBatchBytes(batchBytes)
 	if err != nil {
 		return nil, common.Hash{}, nil, err
 	}
 
 	// Only apply this check when the uncompressed batch data has exceeded 128 KiB.
-	if len(blobBytes) > 131072 {
+	if len(batchBytes) > 131072 {
 		// Check compressed data compatibility.
-		if err = encoding.CheckCompressedDataCompatibility(compressedBlobBytes); err != nil {
-			log.Error("ConstructBlobPayload: compressed data compatibility check failed", "err", err, "uncompressedBlobBytes", hex.EncodeToString(blobBytes), "compressedBlobBytes", hex.EncodeToString(compressedBlobBytes))
+		if err = encoding.CheckCompressedDataCompatibility(blobBytes); err != nil {
+			log.Error("ConstructBlobPayload: compressed data compatibility check failed", "err", err, "batchBytes", hex.EncodeToString(batchBytes), "blobBytes", hex.EncodeToString(blobBytes))
 			return nil, common.Hash{}, nil, err
 		}
 	}
 
 	// convert raw data to BLSFieldElements
-	blob, err := MakeBlobCanonical(compressedBlobBytes)
+	blob, err := MakeBlobCanonical(blobBytes)
 	if err != nil {
 		return nil, common.Hash{}, nil, err
 	}
@@ -347,7 +347,7 @@ func CheckChunkCompressedDataCompatibility(c *encoding.Chunk) (bool, error) {
 		return true, nil
 	}
 	if err = encoding.CheckCompressedDataCompatibility(blobBytes); err != nil {
-		log.Warn("CheckChunkCompressedDataCompatibility: compressed data compatibility check failed", "err", err, "uncompressedBlobBytes", hex.EncodeToString(batchBytes), "compressedBlobBytes", hex.EncodeToString(blobBytes))
+		log.Warn("CheckChunkCompressedDataCompatibility: compressed data compatibility check failed", "err", err, "batchBytes", hex.EncodeToString(batchBytes), "blobBytes", hex.EncodeToString(blobBytes))
 		return false, nil
 	}
 	return true, nil
@@ -369,7 +369,7 @@ func CheckBatchCompressedDataCompatibility(b *encoding.Batch) (bool, error) {
 		return true, nil
 	}
 	if err = encoding.CheckCompressedDataCompatibility(blobBytes); err != nil {
-		log.Warn("CheckBatchCompressedDataCompatibility: compressed data compatibility check failed", "err", err, "uncompressedBlobBytes", hex.EncodeToString(batchBytes), "compressedBlobBytes", hex.EncodeToString(blobBytes))
+		log.Warn("CheckBatchCompressedDataCompatibility: compressed data compatibility check failed", "err", err, "batchBytes", hex.EncodeToString(batchBytes), "blobBytes", hex.EncodeToString(blobBytes))
 		return false, nil
 	}
 	return true, nil
@@ -406,7 +406,7 @@ func constructBatchPayload(chunks []*encoding.Chunk) ([]byte, error) {
 	// metadata consists of num_chunks (2 bytes) and chunki_size (4 bytes per chunk)
 	metadataLength := 2 + MaxNumChunks*4
 
-	// the raw (un-compressed and un-padded) blob payload
+	// batchBytes represents the raw (un-compressed and un-padded) blob payload
 	batchBytes := make([]byte, metadataLength)
 
 	// batch metadata: num_chunks


### PR DESCRIPTION
### Purpose or design rationale of this PR

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
