### PR TITLE
fix: bytes48 not supported by l2geth in syncUpstream

### DIFF
--- a/encoding/codecv1/codecv1.go
+++ b/encoding/codecv1/codecv1.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"sync"
 
-	"github.com/scroll-tech/go-ethereum/accounts/abi"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"
@@ -376,17 +374,24 @@ func (b *DABatch) BlobDataProof() ([]byte, error) {
 		return nil, fmt.Errorf("failed to create KZG proof at point, err: %w, z: %v", err, hex.EncodeToString(b.z[:]))
 	}
 
-	// Memory layout of ``_blobDataProof``:
-	// | z       | y       | kzg_commitment | kzg_proof |
-	// |---------|---------|----------------|-----------|
-	// | bytes32 | bytes32 | bytes48        | bytes48   |
+	return BlobDataProofFromValues(*b.z, y, commitment, proof), nil
+}
 
-	values := []interface{}{*b.z, y, commitment, proof}
-	blobDataProofArgs, err := GetBlobDataProofArgs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get blob data proof args, err: %w", err)
-	}
-	return blobDataProofArgs.Pack(values...)
+// BlobDataProofFromValues creates the blob data proof from the given values.
+// Memory layout of ``_blobDataProof``:
+// | z       | y       | kzg_commitment | kzg_proof |
+// |---------|---------|----------------|-----------|
+// | bytes32 | bytes32 | bytes48        | bytes48   |
+
+func BlobDataProofFromValues(z kzg4844.Point, y kzg4844.Claim, commitment kzg4844.Commitment, proof kzg4844.Proof) []byte {
+	result := make([]byte, 32+32+48+48)
+
+	copy(result[0:32], z[:])
+	copy(result[32:64], y[:])
+	copy(result[64:112], commitment[:])
+	copy(result[112:160], proof[:])
+
+	return result
 }
 
 // Blob returns the blob of the batch.
@@ -564,44 +569,4 @@ func CalculatePaddedBlobSize(dataSize uint64) uint64 {
 	}
 
 	return paddedSize
-}
-
-var (
-	blobDataProofArgs         *abi.Arguments
-	initBlobDataProofArgsOnce sync.Once
-)
-
-// GetBlobDataProofArgs gets the blob data proof arguments for batch commitment and returns error if initialization fails.
-func GetBlobDataProofArgs() (*abi.Arguments, error) {
-	var initError error
-
-	initBlobDataProofArgsOnce.Do(func() {
-		// Initialize bytes32 type
-		bytes32Type, err := abi.NewType("bytes32", "bytes32", nil)
-		if err != nil {
-			initError = fmt.Errorf("failed to initialize abi type bytes32: %w", err)
-			return
-		}
-
-		// Initialize bytes48 type
-		bytes48Type, err := abi.NewType("bytes48", "bytes48", nil)
-		if err != nil {
-			initError = fmt.Errorf("failed to initialize abi type bytes48: %w", err)
-			return
-		}
-
-		// Successfully create the argument list
-		blobDataProofArgs = &abi.Arguments{
-			{Type: bytes32Type, Name: "z"},
-			{Type: bytes32Type, Name: "y"},
-			{Type: bytes48Type, Name: "kzg_commitment"},
-			{Type: bytes48Type, Name: "kzg_proof"},
-		}
-	})
-
-	if initError != nil {
-		return nil, initError
-	}
-
-	return blobDataProofArgs, nil
 }

--- a/encoding/codecv2/codecv2.go
+++ b/encoding/codecv2/codecv2.go
@@ -15,7 +15,6 @@ import (
 	"math/big"
 	"unsafe"
 
-	"github.com/scroll-tech/go-ethereum/accounts/abi"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"
@@ -287,17 +286,7 @@ func (b *DABatch) BlobDataProof() ([]byte, error) {
 		return nil, fmt.Errorf("failed to create KZG proof at point, err: %w, z: %v", err, hex.EncodeToString(b.z[:]))
 	}
 
-	// Memory layout of ``_blobDataProof``:
-	// | z       | y       | kzg_commitment | kzg_proof |
-	// |---------|---------|----------------|-----------|
-	// | bytes32 | bytes32 | bytes48        | bytes48   |
-
-	values := []interface{}{*b.z, y, commitment, proof}
-	blobDataProofArgs, err := GetBlobDataProofArgs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get blob data proof args, err: %w", err)
-	}
-	return blobDataProofArgs.Pack(values...)
+	return codecv1.BlobDataProofFromValues(*b.z, y, commitment, proof), nil
 }
 
 // Blob returns the blob of the batch.
@@ -458,9 +447,4 @@ func compressScrollBatchBytes(batchBytes []byte) ([]byte, error) {
 // where every 32 bytes can store only 31 bytes of actual data, with the first byte being zero.
 func CalculatePaddedBlobSize(dataSize uint64) uint64 {
 	return codecv1.CalculatePaddedBlobSize(dataSize)
-}
-
-// GetBlobDataProofArgs gets the blob data proof arguments for batch commitment and returns error if initialization fails.
-func GetBlobDataProofArgs() (*abi.Arguments, error) {
-	return codecv1.GetBlobDataProofArgs()
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR
This PR removes the `bytes48` ABI argument as it is invalid according to [spec](https://docs.soliditylang.org/en/v0.8.17/abi-spec.html) `bytes<M>: binary type of M bytes, 0 < M <= 32` and has been [fixed upstream](https://github.com/ethereum/go-ethereum/pull/26075) and thus is not compatible anymore with the l2geth upstream version.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
