### PR TITLE
refactor: extend DABlock interface and make decodeBitmap public

### DIFF
--- a/encoding/bitmap.go
+++ b/encoding/bitmap.go
@@ -65,7 +65,7 @@ func constructSkippedBitmap(batchIndex uint64, chunks []*Chunk, totalL1MessagePo
 }
 
 // decodeBitmap decodes skipped L1 message bitmap of the batch from bytes to big.Int's.
-func decodeBitmap(skippedL1MessageBitmap []byte, totalL1MessagePopped int) ([]*big.Int, error) {
+func DecodeBitmap(skippedL1MessageBitmap []byte, totalL1MessagePopped int) ([]*big.Int, error) {
 	length := len(skippedL1MessageBitmap)
 	if length%skippedL1MessageBitmapByteSize != 0 {
 		return nil, fmt.Errorf("skippedL1MessageBitmap length doesn't match, skippedL1MessageBitmap length should be equal 0 modulo %v, length of skippedL1MessageBitmap: %v", skippedL1MessageBitmapByteSize, length)

--- a/encoding/bitmap.go
+++ b/encoding/bitmap.go
@@ -64,7 +64,7 @@ func constructSkippedBitmap(batchIndex uint64, chunks []*Chunk, totalL1MessagePo
 	return skippedL1MessageBitmap, nextIndex, nil
 }
 
-// decodeBitmap decodes skipped L1 message bitmap of the batch from bytes to big.Int's.
+// DecodeBitmap decodes skipped L1 message bitmap of the batch from bytes to big.Int's.
 func DecodeBitmap(skippedL1MessageBitmap []byte, totalL1MessagePopped int) ([]*big.Int, error) {
 	length := len(skippedL1MessageBitmap)
 	if length%skippedL1MessageBitmapByteSize != 0 {

--- a/encoding/bitmap_test.go
+++ b/encoding/bitmap_test.go
@@ -13,7 +13,7 @@ func TestDecodeBitmap(t *testing.T) {
 	skippedL1MessageBitmap, err := hex.DecodeString(bitmapHex)
 	assert.NoError(t, err)
 
-	decodedBitmap, err := decodeBitmap(skippedL1MessageBitmap, 42)
+	decodedBitmap, err := DecodeBitmap(skippedL1MessageBitmap, 42)
 	assert.NoError(t, err)
 
 	isL1MessageSkipped := func(skippedBitmap []*big.Int, index uint64) bool {
@@ -36,9 +36,9 @@ func TestDecodeBitmap(t *testing.T) {
 	assert.False(t, isL1MessageSkipped(decodedBitmap, 40))
 	assert.False(t, isL1MessageSkipped(decodedBitmap, 41))
 
-	_, err = decodeBitmap([]byte{0x00}, 8)
+	_, err = DecodeBitmap([]byte{0x00}, 8)
 	assert.Error(t, err)
 
-	_, err = decodeBitmap([]byte{0x00, 0x00, 0x00, 0x00}, 33)
+	_, err = DecodeBitmap([]byte{0x00, 0x00, 0x00, 0x00}, 33)
 	assert.Error(t, err)
 }

--- a/encoding/interfaces.go
+++ b/encoding/interfaces.go
@@ -16,6 +16,9 @@ type DABlock interface {
 	Number() uint64
 	NumTransactions() uint16
 	NumL1Messages() uint16
+	Timestamp() uint64
+	BaseFee() *big.Int
+	GasLimit() uint64
 }
 
 // DAChunk groups consecutive DABlocks with their transactions.


### PR DESCRIPTION
### Purpose or design rationale of this PR

extend DABlock interface and make decodeBitmap public

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `DecodeBitmap` function is now publicly accessible, allowing for external use in decoding bitmap data.
	- Added new methods `Timestamp()` and `BaseFee()` to the `DABlock` interface, providing additional block-related information.

- **Bug Fixes**
	- Updated test cases to reflect the renaming of `decodeBitmap` to `DecodeBitmap`, ensuring proper error handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->