### PR TITLE
refactor: make IsL1MessageSkipped public

### DIFF
--- a/encoding/bitmap.go
+++ b/encoding/bitmap.go
@@ -80,3 +80,13 @@ func DecodeBitmap(skippedL1MessageBitmap []byte, totalL1MessagePopped int) ([]*b
 	}
 	return skippedBitmap, nil
 }
+
+// IsL1MessageSkipped checks if the L1 message at the given index is skipped.
+func IsL1MessageSkipped(skippedBitmap []*big.Int, index uint64) bool {
+	if index >= uint64(len(skippedBitmap))*256 {
+		return false
+	}
+	quo := index / 256
+	rem := index % 256
+	return skippedBitmap[quo].Bit(int(rem)) == 1
+}

--- a/encoding/bitmap_test.go
+++ b/encoding/bitmap_test.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"encoding/hex"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,25 +15,16 @@ func TestDecodeBitmap(t *testing.T) {
 	decodedBitmap, err := DecodeBitmap(skippedL1MessageBitmap, 42)
 	assert.NoError(t, err)
 
-	isL1MessageSkipped := func(skippedBitmap []*big.Int, index uint64) bool {
-		if index >= uint64(len(skippedBitmap))*256 {
-			return false
-		}
-		quo := index / 256
-		rem := index % 256
-		return skippedBitmap[quo].Bit(int(rem)) == 1
-	}
-
-	assert.True(t, isL1MessageSkipped(decodedBitmap, 0))
-	assert.True(t, isL1MessageSkipped(decodedBitmap, 9))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 10))
-	assert.True(t, isL1MessageSkipped(decodedBitmap, 11))
-	assert.True(t, isL1MessageSkipped(decodedBitmap, 36))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 37))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 38))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 39))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 40))
-	assert.False(t, isL1MessageSkipped(decodedBitmap, 41))
+	assert.True(t, IsL1MessageSkipped(decodedBitmap, 0))
+	assert.True(t, IsL1MessageSkipped(decodedBitmap, 9))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 10))
+	assert.True(t, IsL1MessageSkipped(decodedBitmap, 11))
+	assert.True(t, IsL1MessageSkipped(decodedBitmap, 36))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 37))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 38))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 39))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 40))
+	assert.False(t, IsL1MessageSkipped(decodedBitmap, 41))
 
 	_, err = DecodeBitmap([]byte{0x00}, 8)
 	assert.Error(t, err)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Expose a utility function used in sync from L1 DA feature.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to check if a specific L1 message has been skipped based on a bitmap.
  
- **Bug Fixes**
	- Updated tests to utilize the new function for determining skipped messages, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->