### PR TITLE
fix: check v7 batch compressed data compatibility

### DIFF
--- a/encoding/codecv7.go
+++ b/encoding/codecv7.go
@@ -231,7 +231,7 @@ func (d *DACodecV7) checkCompressedDataCompatibility(payloadBytes []byte) ([]byt
 		return nil, false, fmt.Errorf("failed to compress blob payload: %w", err)
 	}
 
-	if err = checkCompressedDataCompatibility(compressedPayloadBytes); err != nil {
+	if err = checkCompressedDataCompatibilityV7(compressedPayloadBytes); err != nil {
 		log.Warn("Compressed data compatibility check failed", "err", err, "payloadBytes", hex.EncodeToString(payloadBytes), "compressedPayloadBytes", hex.EncodeToString(compressedPayloadBytes))
 		return nil, false, nil
 	}

--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -384,18 +384,6 @@ func TestCodecV7BatchStandardTestCasesEnableCompression(t *testing.T) {
 		})
 	}
 
-	repeat := func(element byte, count int) string {
-		result := make([]byte, 0, count)
-		for i := 0; i < count; i++ {
-			result = append(result, element)
-		}
-		return "0x" + common.Bytes2Hex(result)
-	}
-
-	// Taking into consideration compression, we allow up to 5x of max blob bytes minus 5 byte for the blob envelope header.
-	// We subtract 74 bytes for the blobPayloadV7 metadata.
-	//compressableAvailableBytes := maxEffectiveBlobBytes*5 - 5 - blobPayloadV7MinEncodedLength
-	maxAvailableBytesCompressable := 5*maxEffectiveBlobBytes - 5 - blobPayloadV7MinEncodedLength
 	maxAvailableBytesIncompressable := maxEffectiveBlobBytes - 5 - blobPayloadV7MinEncodedLength
 	// 52 bytes for each block as per daBlockV7 encoding.
 	bytesPerBlock := 52
@@ -454,18 +442,6 @@ func TestCodecV7BatchStandardTestCasesEnableCompression(t *testing.T) {
 			numBlocks:                 2,
 			txData:                    []string{generateRandomData(maxAvailableBytesIncompressable/2 - bytesPerBlock*2)},
 			expectedBlobVersionedHash: "0x017d7f0d569464b5c74175679e5f2bc880fcf5966c3e1928c9675c942b5274f0",
-		},
-		{
-			name:                      "single block, single tx, full blob repeat data",
-			numBlocks:                 1,
-			txData:                    []string{repeat(0x12, maxAvailableBytesCompressable-bytesPerBlock)},
-			expectedBlobVersionedHash: "0x01f5d7bbfe7deb429bcbdd7347606359bca75cb93b9198e8f089b82e45f92b43",
-		},
-		{
-			name:                      "2 blocks, single 2, full blob random data",
-			numBlocks:                 2,
-			txData:                    []string{repeat(0x12, maxAvailableBytesCompressable/2-bytesPerBlock*2), repeat(0x13, maxAvailableBytesCompressable/2-bytesPerBlock*2)},
-			expectedBlobVersionedHash: "0x01dccca3859640c50e0058fd42eaf14f942070e6497a4e2ba507b4546280a772",
 		},
 		{
 			name:        "single block, single tx, full blob random data -> error because 1 byte too big",

--- a/encoding/da.go
+++ b/encoding/da.go
@@ -465,6 +465,52 @@ func checkCompressedDataCompatibility(data []byte) error {
 	return nil
 }
 
+// Fast testing if the compressed data (v7) is compatible with our circuit
+// (require specified frame header and each block is compressed)
+func checkCompressedDataCompatibilityV7(data []byte) error {
+	if len(data) < 16 {
+		return fmt.Errorf("too small size (0x%x), what is it?", data)
+	}
+
+	fheader := data[0]
+	// it is not the encoding type we expected in our zstd header
+	if fheader&63 != 32 {
+		return fmt.Errorf("unexpected header type (%x)", fheader)
+	}
+
+	// skip content size
+	switch fheader >> 6 {
+	case 0:
+		data = data[2:]
+	case 1:
+		data = data[3:]
+	case 2:
+		data = data[5:]
+	case 3:
+		data = data[9:]
+	default:
+		panic("impossible")
+	}
+
+	isLast := false
+	// scan each block until done
+	for len(data) > 3 && !isLast {
+		isLast = (data[0] & 1) == 1
+		blkSize := (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3
+		if len(data) < 3+int(blkSize) {
+			return fmt.Errorf("wrong data len {%d}, expect min {%d}", len(data), 3+blkSize)
+		}
+		data = data[3+blkSize:]
+	}
+
+	// Should we return invalid if isLast is still false?
+	if !isLast {
+		return fmt.Errorf("unexpected end before last block")
+	}
+
+	return nil
+}
+
 // makeBlobCanonical converts the raw blob data into the canonical blob representation of 4096 BLSFieldElements.
 // The canonical blob representation is a 32-byte array where every 31 bytes are prepended with 1 zero byte.
 // The kzg4844.Blob is a 4096-byte array, thus 0s are padded to the end of the array.


### PR DESCRIPTION
### Purpose or design rationale of this PR

For v7 batches, uncompressed cases are resolved. This PR removes the uncompressed case checks and only keeps sanity checks. If sanity check fails, rollup-relayer should halt and wait for manual fix.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] fix: A bug fix

### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
