### PR TITLE
build: require exact zstd version

### DIFF
--- a/libzstd/encoder-standard/Cargo.toml
+++ b/libzstd/encoder-standard/Cargo.toml
@@ -9,4 +9,4 @@ name = "encoder_standard"
 crate-type = ["staticlib"]
 
 [dependencies]
-zstd = { version = "0.13", features = ["experimental"] }
+zstd = { version = "=0.13.3", features = ["experimental"] }


### PR DESCRIPTION
### Purpose or design rationale of this PR

Exact same version as the one used in Reth, just to be safe.

Note: This does not change anything for this repo; `Cargo.lock` already locks to this version.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency version for zstd to require exactly version 0.13.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->