### PR TITLE
fix(zstd decompression): limit concurrency to 1 to prevent deadlock in zstd library

### DIFF
--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"math/rand"
 	"net/http"
-	_ "net/http"
 	_ "net/http/pprof"
 	"strings"
 	"testing"
@@ -22,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDecodeAllDeadlock tests the decompression of random bytes to trigger deadlock in zstd library.
-
+// TestDecodeAllDeadlock tests the decompression of random bytes to trigger deadlock in zstd library
+// with setting of zstd.WithDecoderConcurrency(2).
 func TestDecodeAllDeadlock(t *testing.T) {
 	t.Skip("Skip test that triggers deadlock in zstd library")
 

--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	crand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -32,7 +33,8 @@ func TestDecodeAllDeadlock(t *testing.T) {
 
 	// generate some random bytes
 	randomBytes := make([]byte, maxBlobBytes)
-	rand.Read(randomBytes)
+	_, err := crand.Read(randomBytes)
+	require.NoError(t, err)
 
 	c := NewDACodecV8()
 

--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -24,7 +24,7 @@ import (
 // TestDecodeAllDeadlock tests the decompression of random bytes to trigger deadlock in zstd library.
 
 func TestDecodeAllDeadlock(t *testing.T) {
-	//t.Skip("Skip test that triggers deadlock in zstd library")
+	t.Skip("Skip test that triggers deadlock in zstd library")
 
 	go func() {
 		log.Println(http.ListenAndServe("localhost:6060", nil))

--- a/encoding/codecv7_types.go
+++ b/encoding/codecv7_types.go
@@ -482,7 +482,7 @@ func decompressV7Bytes(compressedBytes []byte) ([]byte, error) {
 
 	compressedBytes = append(zstdMagicNumber, compressedBytes...)
 	r := bytes.NewReader(compressedBytes)
-	zr, err := zstd.NewReader(r)
+	zr, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zstd reader: %w", err)
 	}

--- a/encoding/da.go
+++ b/encoding/da.go
@@ -552,7 +552,7 @@ func decompressScrollBlobToBatch(compressedBytes []byte) ([]byte, error) {
 	batchOfBytes := make([]byte, readBatchSize)
 
 	r := bytes.NewReader(compressedBytes)
-	zr, err := zstd.NewReader(r)
+	zr, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR
This PR limits the decoder concurrency of `zstd.NewReader` to 1. https://github.com/scroll-tech/da-codec/blob/3521fcd6eb1936e43887a65214fdecbdbf306b09/encoding/codecv7_types.go#L485

This is to prevent a deadlock somewhere downstream in the library that seems to occur only with a decoder concurrency of exactly 2: `zstd.WithDecoderConcurrency(1)`. 


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reduced decompression concurrency to improve reliability and stability during heavy decoding workloads.

- Tests
  - Added a high-load decompression stress test (skipped by default) with profiling enabled to validate robustness and detect potential deadlocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->