### PR TITLE
fix: Consider all transactions in chunk hash

### DIFF
--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -84,7 +84,6 @@ func TestChunkHashUnique(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, chunkHash1, chunkHash2)
-
 }
 
 // TestCodecV7DABlockEncodeDecode tests the encoding and decoding of daBlockV7.

--- a/encoding/codecv7_test.go
+++ b/encoding/codecv7_test.go
@@ -48,6 +48,45 @@ func TestDecodeAllDeadlock(t *testing.T) {
 	}
 }
 
+// TestChunkHashUnique tests that the hashes of any two different chunks are different.
+func TestChunkHashUnique(t *testing.T) {
+	// construct a chunk with a single, empty block
+	chunk1 := newDAChunkV7([]DABlock{&daBlockV7{
+		daBlockV0: daBlockV0{
+			number:          1,
+			timestamp:       0,
+			baseFee:         big.NewInt(0),
+			gasLimit:        0,
+			numTransactions: 0,
+			numL1Messages:   0,
+		},
+		lowestL1MessageQueueIndex: 0,
+	}}, [][]*types.TransactionData{{}})
+
+	chunkHash1, err := chunk1.Hash()
+	require.NoError(t, err)
+
+	// construct a 2nd chunk with a single, empty block,
+	// the only difference is the block number.
+	chunk2 := newDAChunkV7([]DABlock{&daBlockV7{
+		daBlockV0: daBlockV0{
+			number:          2,
+			timestamp:       0,
+			baseFee:         big.NewInt(0),
+			gasLimit:        0,
+			numTransactions: 0,
+			numL1Messages:   0,
+		},
+		lowestL1MessageQueueIndex: 0,
+	}}, [][]*types.TransactionData{{}})
+
+	chunkHash2, err := chunk2.Hash()
+	require.NoError(t, err)
+
+	require.NotEqual(t, chunkHash1, chunkHash2)
+
+}
+
 // TestCodecV7DABlockEncodeDecode tests the encoding and decoding of daBlockV7.
 func TestCodecV7DABlockEncodeDecode(t *testing.T) {
 	codecV7, err := CodecFromVersion(CodecV7)

--- a/encoding/codecv7_types.go
+++ b/encoding/codecv7_types.go
@@ -460,10 +460,6 @@ func (c *daChunkV7) Hash() (common.Hash, error) {
 	// concatenate l1 tx hashes
 	for _, blockTxs := range c.transactions {
 		for _, txData := range blockTxs {
-			if txData.Type != types.L1MessageTxType {
-				continue
-			}
-
 			hashBytes := common.FromHex(txData.TxHash)
 			if len(hashBytes) != common.HashLength {
 				return common.Hash{}, fmt.Errorf("unexpected hash: %s", txData.TxHash)

--- a/encoding/codecv7_types.go
+++ b/encoding/codecv7_types.go
@@ -447,16 +447,24 @@ func newDAChunkV7(blocks []DABlock, transactions [][]*types.TransactionData) *da
 }
 
 // Hash computes the hash of the DAChunk data.
+// Note: Starting from v7, the chunk hash is not used in
+// the protocol anymore, it is simply a unique identifier.
 func (c *daChunkV7) Hash() (common.Hash, error) {
 	var dataBytes []byte
 
 	// concatenate block contexts
 	for _, block := range c.blocks {
+		// append block number
+		var tmp [8]byte
+		binary.BigEndian.PutUint64(tmp[:], block.Number())
+		dataBytes = append(dataBytes, tmp[:]...)
+
+		// append encoded block context
 		encodedBlock := block.Encode()
 		dataBytes = append(dataBytes, encodedBlock...)
 	}
 
-	// concatenate l1 tx hashes
+	// concatenate tx hashes
 	for _, blockTxs := range c.transactions {
 		for _, txData := range blockTxs {
 			hashBytes := common.FromHex(txData.TxHash)


### PR DESCRIPTION
### Purpose or design rationale of this PR

The current v7 and v8 chunk hashing is prone to chunk hash collision, which has happened on mainnet: Two consecutive blocks with mostly identical header fields (including timestamp), each including enough transactions to fill a chunk. This results in two consecutive chunks with identical hashes.

The reason of the chunk hash collision is that some chunk contents are not considered during hashing, most importantly: The block number and the L2 transaction hashes.

This PR updates the chunk hash function to ensure that chunk hashes are unique. Since chunk hashes are only used for `rollup-relayer`'s internal bookkeeping, and they're not used anymore in the contracts, provers, or in l2geth rollup-verifier, we can upgrade directly to this new hash.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hash computation now includes block numbers and all transaction hashes, so resulting chunk identifiers may differ from prior releases.
  * Stricter validation: transactions with missing or invalid hashes now raise errors instead of being skipped, improving robustness and fail-fast behavior.
  * Chunk hash is treated as a unique identifier rather than a protocol-used value; downstream verification/caching may be affected.

* **Tests**
  * Added a test ensuring chunks with different block numbers produce distinct hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->