### PR TITLE
fix(zstd decompression): add correct usage of zstd library

### DIFF
--- a/encoding/codecv7_types.go
+++ b/encoding/codecv7_types.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -478,17 +477,14 @@ func (c *daChunkV7) Hash() (common.Hash, error) {
 
 // decompressV7Bytes decompresses the given blob bytes into the original payload bytes.
 func decompressV7Bytes(compressedBytes []byte) ([]byte, error) {
-	var res []byte
-
 	compressedBytes = append(zstdMagicNumber, compressedBytes...)
-	r := bytes.NewReader(compressedBytes)
-	zr, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(1))
+	zr, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zstd reader: %w", err)
 	}
 	defer zr.Close()
 
-	res, err = zr.DecodeAll(compressedBytes, res)
+	res, err := zr.DecodeAll(compressedBytes, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decompress zstd data: %w", err)
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

In [zstd](https://github.com/klauspost/compress/tree/master/zstd#usage-1) the usage of stateless mode is described. 

```
// Create a reader that caches decompressors.
// For this operation type we supply a nil Reader.
var decoder, _ = zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))

// Decompress a buffer. We don't supply a destination buffer,
// so it will be allocated by the decoder.
func Decompress(src []byte) ([]byte, error) {
    return decoder.DecodeAll(src, nil)
}
```

In our case we were initializing the reader (ie stateful mode) with a buffer and then using the stateless `DecodeAll` method. 


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
