### PR TITLE
fix: consider RLE blocks in zstd compatibility check

### DIFF
--- a/encoding/da.go
+++ b/encoding/da.go
@@ -497,13 +497,13 @@ func checkCompressedDataCompatibilityV7(data []byte) error {
 		isLast = (data[0] & 1) == 1
 		blkType := (data[0] >> 1) & 3
 		var blkSize uint
-		if blkType == 1 {// RLE Block
+		if blkType == 1 { // RLE Block
 			blkSize = 1
 		} else {
 			if blkType == 3 {
 				return fmt.Errorf("encounter reserved block type at %v", data)
 			}
-			blkSize = (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3	
+			blkSize = (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3
 		}
 		if len(data) < 3+int(blkSize) {
 			return fmt.Errorf("wrong data len {%d}, expect min {%d}", len(data), 3+blkSize)

--- a/encoding/da.go
+++ b/encoding/da.go
@@ -495,7 +495,16 @@ func checkCompressedDataCompatibilityV7(data []byte) error {
 	// scan each block until done
 	for len(data) > 3 && !isLast {
 		isLast = (data[0] & 1) == 1
-		blkSize := (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3
+		blkType := (data[0] >> 1) & 3
+		var blkSize uint
+		if blkType == 1 {// RLE Block
+			blkSize = 1
+		} else {
+			if blkType == 3 {
+				return fmt.Errorf("encounter reserved block type at %v", data)
+			}
+			blkSize = (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3	
+		}
 		if len(data) < 3+int(blkSize) {
 			return fmt.Errorf("wrong data len {%d}, expect min {%d}", len(data), 3+blkSize)
 		}


### PR DESCRIPTION
Fix an issue that the new `checkCompressedDataCompatibilityV7` do not consider RLE type block, which would be possible when we have switched to official zstd for data compression

After this change, `checkCompressedDataCompatibilityV7` will serve as a sanity check, it will only return error if there is some issue with the compressed data. Examples include: Data is corrupted, data is truncated, compressed data uses unsupported features (e.g. dictionary). If the compression module is configured correctly, `checkCompressedDataCompatibilityV7` will never fail.

See the spec for more details: https://datatracker.ietf.org/doc/html/rfc8878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of compressed data blocks to reduce decoding failures.
  * Correctly interprets block types, enforcing proper size for RLE blocks and rejecting reserved types with clear errors.
  * Provides more accurate data length checks and error reporting, improving reliability when processing V7-compressed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->