### PR TITLE
Revert "fix: consider RLE blocks in zstd compatibility check"

### DIFF
--- a/encoding/da.go
+++ b/encoding/da.go
@@ -495,16 +495,7 @@ func checkCompressedDataCompatibilityV7(data []byte) error {
 	// scan each block until done
 	for len(data) > 3 && !isLast {
 		isLast = (data[0] & 1) == 1
-		blkType := (data[0] >> 1) & 3
-		var blkSize uint
-		if blkType == 1 { // RLE Block
-			blkSize = 1
-		} else {
-			if blkType == 3 {
-				return fmt.Errorf("encounter reserved block type at %v", data)
-			}
-			blkSize = (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3
-		}
+		blkSize := (uint(data[2])*65536 + uint(data[1])*256 + uint(data[0])) >> 3
 		if len(data) < 3+int(blkSize) {
 			return fmt.Errorf("wrong data len {%d}, expect min {%d}", len(data), 3+blkSize)
 		}


### PR DESCRIPTION
Reverts scroll-tech/da-codec#64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal data block handling logic in compression compatibility checks for improved code maintainability and more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->